### PR TITLE
Fix power button behavior with USB-C charging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,13 @@ TARGET = badgemagic-ch582
 ######################################
 # Uncomment below line to enable debugging
 # DEBUG = 1
-# Comment below to build for micro USB version
+
+# Hardware version selection:
+# - Set USBC_VERSION = 1 for USB-C hardware (uses GPIO B6 for LED pin T)
+# - Comment out or set to 0 for micro-USB hardware (uses GPIO B23 for LED pin T)
+# Default: USB-C version
 USBC_VERSION = 1
+
 # optimization for size
 OPT = -Os
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ TARGET = badgemagic-ch582
 ######################################
 # Uncomment below line to enable debugging
 # DEBUG = 1
-# Uncomment below to build for USB-C version
-# USBC_VERSION = 1
+# Comment below to build for micro USB version
+USBC_VERSION = 1
 # optimization for size
 OPT = -Os
 

--- a/src/main.c
+++ b/src/main.c
@@ -68,6 +68,11 @@ static void disp_clock();
 __HIGH_CODE
 static void change_mode()
 {
+	if (mode == BOOT) {
+		mode = NORMAL;
+		return;
+	}
+
 	NEXT_STATE(mode, 0, MODES_COUNT);
 	const static void (*modes[])(void) = {
 		NULL,

--- a/src/main.c
+++ b/src/main.c
@@ -65,14 +65,32 @@ static void mode_setup_download();
 static void mode_setup_normal();
 static void disp_clock();
 
+/*
+ * Mode state machine (KEY1 button press handler)
+ *
+ * Standard cycle: NORMAL(1) -> DOWNLOAD(2) -> POWER_OFF(3) -> NORMAL(1) -> ...
+ *
+ * Special case: BOOT(0)
+ *   - BOOT is the initial mode on power-on, shows charging status during startup
+ *   - Also entered automatically when USB charging detected (see DETECT_CHARGING event)
+ *   - Not part of standard mode cycle (user cannot cycle INTO boot via button)
+ *   - When user presses button in BOOT: transition directly to NORMAL
+ *   - Rationale: Allows user to exit charging display and prevents accidental
+ *     power-off during charging (since BOOT is outside the normal cycle)
+ *
+ * Implementation note: This special case should be preserved when adding new modes.
+ * BOOT should always transition directly to NORMAL on button press.
+ */
 __HIGH_CODE
 static void change_mode()
 {
+	// Special case: BOOT mode exits directly to NORMAL (not part of cycle)
 	if (mode == BOOT) {
 		mode = NORMAL;
 		return;
 	}
 
+	// Standard mode cycling
 	NEXT_STATE(mode, 0, MODES_COUNT);
 	const static void (*modes[])(void) = {
 		NULL,

--- a/src/power.c
+++ b/src/power.c
@@ -10,11 +10,18 @@ void poweroff()
 	GPIOA_ModeCfg(GPIO_Pin_All, GPIO_ModeIN_Floating);
 	GPIOB_ModeCfg(GPIO_Pin_All, GPIO_ModeIN_Floating);
 
-	// Configure wake-up - only KEY1
-	// Note: Charging wake-up (GPIO A0) disabled because it doesn't work
-	// reliably on USB-C version and interferes with KEY1 wake-up
+	// Configure wake-up sources
+	// KEY1: Always enabled (button wake-up)
 	GPIOA_ModeCfg(KEY1_PIN, GPIO_ModeIN_PD);
 	GPIOA_ITModeCfg(KEY1_PIN, GPIO_ITMode_RiseEdge);
+
+#ifndef USBC_VERSION
+	// CHARGE_STT: Enable for micro-USB version
+	// Note: Disabled on USB-C version because it interferes with KEY1 wake-up
+	GPIOA_ModeCfg(CHARGE_STT_PIN, GPIO_ModeIN_PU);
+	GPIOA_ITModeCfg(CHARGE_STT_PIN, GPIO_ITMode_FallEdge);
+#endif
+
 	PFIC_EnableIRQ(GPIO_A_IRQn);
 	PWR_PeriphWakeUpCfg(ENABLE, RB_SLP_GPIO_WAKE, Long_Delay);
 

--- a/src/power.c
+++ b/src/power.c
@@ -10,11 +10,11 @@ void poweroff()
 	GPIOA_ModeCfg(GPIO_Pin_All, GPIO_ModeIN_Floating);
 	GPIOB_ModeCfg(GPIO_Pin_All, GPIO_ModeIN_Floating);
 
-	// Configure wake-up
+	// Configure wake-up - only KEY1
+	// Note: Charging wake-up (GPIO A0) disabled because it doesn't work
+	// reliably on USB-C version and interferes with KEY1 wake-up
 	GPIOA_ModeCfg(KEY1_PIN, GPIO_ModeIN_PD);
 	GPIOA_ITModeCfg(KEY1_PIN, GPIO_ITMode_RiseEdge);
-	GPIOA_ModeCfg(CHARGE_STT_PIN, GPIO_ModeIN_PU);
-	GPIOA_ITModeCfg(CHARGE_STT_PIN, GPIO_ITMode_FallEdge);
 	PFIC_EnableIRQ(GPIO_A_IRQn);
 	PWR_PeriphWakeUpCfg(ENABLE, RB_SLP_GPIO_WAKE, Long_Delay);
 


### PR DESCRIPTION
## Summary
  Fixes power button issues on USB-C version when charging cable is connected.

  This PR also makes USBC on by default as this is more widely used at this point than micro-usb.

  ## Changes
  - **src/power.c**: Removed GPIO A0 (CHARGE_STT_PIN) from wake-up configuration in `poweroff()`. This pin interferes with KEY1 wake-up when USB is connected.
  - **src/main.c**: Modified `change_mode()` to exit charging mode (BOOT) directly to NORMAL mode instead of cycling through all modes, preventing accidental power-off while charging.

  ## Testing
  - [x] Press power button → should power off at some point
  - [x] While in charging mode, press power button → does not power off
  - [x] All pixels working correctly on USB-C version

  ## Related Issues
  Fixes power button wake-up and prevents accidental shutdown during charging on USB-C hardware revision.

## Summary by Sourcery

Adjust power management and build defaults to improve USB-C device behavior while charging.

Bug Fixes:
- Prevent power button wake-up issues on USB-C hardware by disabling the charging status pin as a wake source.
- Avoid accidental power-off when exiting charging mode by transitioning directly from boot/charging to normal mode.

Build:
- Set USB-C hardware configuration as the default build target instead of micro USB.