### PR TITLE
feat: allow skipping splash screen with 0ms duration (#115)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -6,7 +6,7 @@
 #include "xbm.h"
 #include "leddrv.h"
 
-#define SPLASH_MIN_SPEED_T (10) // ms
+#define SPLASH_MIN_SPEED_T (0) // ms
 
 #define SPLASH_MAX_WIDTH (48) // pixels
 #define SPLASH_MAX_HEIGHT (44) // pixels


### PR DESCRIPTION
Addresses #115 by allowing users to skip the splash screen.

Previously, SPLASH_MIN_SPEED_T imposed a minimum duration. By setting this to 0, users can now skip the splash screen.

Changes

    Updated SPLASH_MIN_SPEED_T to 0 in src/config.h

Testing

    Verified on local build using the MRS toolchain.

Closes #115

## Summary by Sourcery

New Features:
- Enable configuring the splash screen with a 0ms minimum duration to skip it entirely.