### PR TITLE
feat.: add BLE security via 4-digit auth code

### DIFF
--- a/src/BLEsecurity.md
+++ b/src/BLEsecurity.md
@@ -20,7 +20,7 @@ When security is enabled:
 
 | Byte  | Content                                                                |
 |-------|------------------------------------------------------------------------|
-| 0–3   | PIN digits as ASCII characters (e.g. `6512` → `0x36 0x35 0x31 0x32`) |
+| 0–3   | PIN digits as ASCII characters (e.g. `6512` → `0x36 0x35 0x31 0x32`)   |
 | 4–15  | Zero padding                                                           |
 
 4. If the PIN matches, all subsequent  transfers are accepted normally
@@ -57,7 +57,7 @@ A PIN write to `0xFEE1` returns:
 | PIN matched                                    | `SUCCESS` (`0x00`)          |
 | PIN wrong                                      | `ATT_ERR_UNLIKELY` (`0x0E`) |
 | Not a valid PIN attempt                        | `ATT_ERR_UNLIKELY` (`0x0E`) |
-| `wang` sent before PIN when security enabled | `ATT_ERR_UNLIKELY` (`0x0E`) |
+| `wang` sent before PIN when security enabled   | `ATT_ERR_UNLIKELY` (`0x0E`) |
 
 #### Impact on third-party clients
 

--- a/src/BLEsecurity.md
+++ b/src/BLEsecurity.md
@@ -1,0 +1,72 @@
+### BLE Security (Optional PIN Authentication)
+
+This firmware includes an optional PIN-based authentication mechanism for the
+legacy profile. When enabled, the badge displays a 4-digit PIN on the LED matrix
+upon entering BT-PAIRING mode. A client must send this PIN before any bitmap
+transfer will be accepted.
+
+Security is **disabled by default**, preserving full backward compatibility with
+existing apps, libraries, and tools. It can be enabled via the badge's
+**SECURITY** menu.
+
+#### Authentication flow
+
+When security is enabled:
+
+1. Put the badge in BT-PAIRING mode — a 4-digit PIN is shown on the display.
+2. Connect to the badge over BLE.
+3. Send the PIN as a single write to characteristic `0xFEE1` before any `wang`
+   packet:
+
+| Byte  | Content                                                                |
+|-------|------------------------------------------------------------------------|
+| 0–3   | PIN digits as ASCII characters (e.g. `6512` → `0x36 0x35 0x31 0x32`) |
+| 4–15  | Zero padding                                                           |
+
+4. If the PIN matches, all subsequent  transfers are accepted normally
+   for the duration of the connection.
+5. If the PIN does not match, the write is rejected and the transfer is blocked.
+6. If a `wang` packet is sent before a correct PIN, it is rejected.
+
+#### Backward compatibility
+
+When security is **disabled** (default), the badge behaves identically to the
+original OEM firmware — `wang` transfers are accepted directly without any
+PIN. No changes are required in existing clients.
+
+When security is **enabled**, clients that do not implement the PIN flow will
+have their transfers rejected. The badge owner can also temporarily bypass the
+PIN for a single session by pressing **KEY4** while in BT-PAIRING mode — this
+allows legacy clients to connect without a PIN for that session only, reverting
+to secure mode on the next disconnect.
+
+#### Auth state lifecycle
+
+- A new PIN is generated each time BT-PAIRING mode is entered.
+- Auth state resets on every BLE disconnect — the PIN must be sent again on
+  reconnect.
+- The security setting (enabled/disabled) persists across reboots and is stored
+  in flash.
+
+#### Return codes
+
+A PIN write to `0xFEE1` returns:
+
+| Result                                         | ATT response                |
+|------------------------------------------------|-----------------------------|
+| PIN matched                                    | `SUCCESS` (`0x00`)          |
+| PIN wrong                                      | `ATT_ERR_UNLIKELY` (`0x0E`) |
+| Not a valid PIN attempt                        | `ATT_ERR_UNLIKELY` (`0x0E`) |
+| `wang` sent before PIN when security enabled | `ATT_ERR_UNLIKELY` (`0x0E`) |
+
+#### Impact on third-party clients
+
+Third-party libraries and tools (e.g. Python, Rust, Go) are unaffected as long
+as the badge owner keeps security disabled (default). If security is enabled,
+clients need to:
+
+1. Detect the PIN prompt — the badge will reject the first `"wang"` write with
+   an error if security is on.
+2. Prompt the user to enter the PIN shown on the badge.
+3. Send the PIN packet to `0xFEE1` as described above.
+4. Retry the `wang` transfer.

--- a/src/auxbtn.c
+++ b/src/auxbtn.c
@@ -41,10 +41,6 @@ static int aux_adc_read()
     ADC_ChannelCfg(BATT_ADC_CHANNEL);
     ret = ret / ADC_SAMPLE_COUNT;
 
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "ADC: %d\n", ret);
-    cdc_tx_poll((uint8_t *)buf, len, 10);
-
     return ret;
 }
 /*

--- a/src/ble/peripheral.c
+++ b/src/ble/peripheral.c
@@ -1,6 +1,7 @@
 #include "CH58xBLE_LIB.h"
 #include "setup.h"
 #include "../config.h"
+#include "../legacyctrl.h"
 
 #define ADV_UUID    (0xFEE0)
 
@@ -90,6 +91,7 @@ static void link_onTerminated(gapRoleEvent_t *pe)
 {
 	gapTerminateLinkEvent_t *event = (gapTerminateLinkEvent_t *)pe;
 	GAPRole_TerminateLink(pe->linkCmpl.connectionHandle);
+	legacy_reset_auth(); //clears authorised flag on disconnect
 	enable_advertising(TRUE);
 
 	if(event->connectionHandle == conn_list.connHandle) {

--- a/src/config.c
+++ b/src/config.c
@@ -9,7 +9,6 @@
 #include "util/crc.h"
 
 #include "ISP583.h"
-#include "CH58xBLE_LIB.h"
 #include <stdlib.h>
 
 #define CFG_SIZE sizeof(badge_cfg_t)
@@ -21,9 +20,9 @@ badge_cfg_t badge_cfg;
 void cfg_fallback()
 {
 	badge_cfg.ble_always_on = 0;
-	tmos_memcpy(badge_cfg.ble_devname, "LED Badge Magic\0\0\0\0", 20);
+	memcpy(badge_cfg.ble_devname, "LED Badge Magic\0\0\0\0", 20);
 	/* OEM app testing: */
-	// tmos_memcpy(badge_cfg.ble_devname, "LSLED\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 20);
+	// memcpy(badge_cfg.ble_devname, "LSLED\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 20);
 
 	badge_cfg.led_brightness = 0;
 	badge_cfg.led_scan_freq = 2000;
@@ -31,15 +30,13 @@ void cfg_fallback()
 	badge_cfg.splash_speedT = 30; // ms
 
 	int splash_size = ALIGN_1BYTE(splash.w) * splash.h;
-	if (splash_size > (int)sizeof(badge_cfg.splash_bm_bits))
-		splash_size = sizeof(badge_cfg.splash_bm_bits);
-	tmos_memset(badge_cfg.splash_bm_bits, 0, sizeof(badge_cfg.splash_bm_bits));
-	tmos_memcpy(badge_cfg.splash_bm_bits, splash.bits, splash_size);
+	memcpy(badge_cfg.splash_bm_bits, splash.bits, splash_size);
 	badge_cfg.splash_bm_w = splash.w;
 	badge_cfg.splash_bm_h = splash.h;
 	badge_cfg.splash_bm_fh = splash.fh;
 
 	badge_cfg.reset_rx = FALSE;
+	badge_cfg.ble_security = 1;  // secure by default
 }
 
 void cfg_update_crc(badge_cfg_t *cfg)

--- a/src/config.c
+++ b/src/config.c
@@ -36,7 +36,7 @@ void cfg_fallback()
 	badge_cfg.splash_bm_fh = splash.fh;
 
 	badge_cfg.reset_rx = FALSE;
-	badge_cfg.ble_security = 1;  // secure by default
+	badge_cfg.ble_security = 0;  // insecure by default
 }
 
 void cfg_update_crc(badge_cfg_t *cfg)

--- a/src/config.h
+++ b/src/config.h
@@ -28,6 +28,7 @@ typedef struct {
 	// Speed in period of micro second. The lower value, the higher speed
 	uint16_t splash_speedT;
 	uint8_t reset_rx; // Reset after bitmap received
+	uint8_t ble_security;  // 1 = require PIN for BLE transfers, 0 = open
 
 	uint8_t crc;
 } __attribute__((packed)) badge_cfg_t;

--- a/src/legacyctrl.c
+++ b/src/legacyctrl.c
@@ -4,6 +4,21 @@
 #include "debug.h"
 #include "legacyctrl.h"
 #include "CH58x_common.h"
+#include "usb/usb.h"
+
+static uint16_t auth_code = 0;
+static uint8_t  authorized = 0;
+
+void legacy_set_auth_code(uint16_t code)
+{
+	auth_code  = code;
+	authorized = 0;
+}
+
+void legacy_reset_auth()
+{
+	authorized = 0;
+}
 
 int legacy_ble_rx(uint8_t *val, uint16_t len)
 {
@@ -12,64 +27,116 @@ int legacy_ble_rx(uint8_t *val, uint16_t len)
 	static uint8_t *data;
 
 	if (len != LEGACY_TRANSFER_WIDTH) {
-		PRINT("Transfer width is not matched\n");
+		char buf[32];
+		int blen = snprintf(buf, sizeof(buf), "BLE: width mismatch %d\n", len);
+		cdc_tx_poll((uint8_t *)buf, blen, 10);
 		return -1;
 	}
 
-	PRINT("val[%d]: ", len);
-	for (int i=0; i<len; i++) {
-		PRINT("%02X ", val[i]);
+	if (!authorized) {
+		if (!memcmp(val, "wang", 4)) {
+			char buf[32];
+			int blen = snprintf(buf, sizeof(buf), "BLE: rejected - not authed\n");
+			cdc_tx_poll((uint8_t *)buf, blen, 10);
+			return -4;
+		}
+
+		if (len >= 4
+			&& val[0] >= '0' && val[0] <= '9'
+			&& val[1] >= '0' && val[1] <= '9'
+			&& val[2] >= '0' && val[2] <= '9'
+			&& val[3] >= '0' && val[3] <= '9')
+		{
+			uint16_t attempt = (val[0] - '0') * 1000
+			                 + (val[1] - '0') * 100
+			                 + (val[2] - '0') * 10
+			                 + (val[3] - '0');
+
+			if (attempt == auth_code) {
+				authorized = 1;
+				char buf[32];
+				int blen = snprintf(buf, sizeof(buf), "BLE: auth OK\n");
+				cdc_tx_poll((uint8_t *)buf, blen, 10);
+				return 0;
+			} else {
+				char buf[48];
+				int blen = snprintf(buf, sizeof(buf), "BLE: wrong code got=%04d exp=%04d\n", attempt, auth_code);
+				cdc_tx_poll((uint8_t *)buf, blen, 10);
+				return -5;
+			}
+		}
+
+		char buf[32];
+		int blen = snprintf(buf, sizeof(buf), "BLE: invalid code attempt\n");
+		cdc_tx_poll((uint8_t *)buf, blen, 10);
+		return -5;
 	}
-	PRINT("\n");
+
+	// Authorized path — log transfer progress over CDC
+	{
+		char buf[48];
+		int blen = snprintf(buf, sizeof(buf), "BLE: rx packet c=%d len=%d\n", c, len);
+		cdc_tx_poll((uint8_t *)buf, blen, 10);
+	}
 
 	if (c == 0) {
 		if (memcmp(val, "wang", 5)) {
-			PRINT("Not a header\n");
+			char buf[32];
+			int blen = snprintf(buf, sizeof(buf), "BLE: not a header\n");
+			cdc_tx_poll((uint8_t *)buf, blen, 10);
 			return -2;
 		} else {
 			free(data);
 			data = malloc(sizeof(data_legacy_t));
 			if (!data) {
-				PRINT("insufficient memory\n");
+				char buf[32];
+				int blen = snprintf(buf, sizeof(buf), "BLE: malloc failed\n");
+				cdc_tx_poll((uint8_t *)buf, blen, 10);
 				return -3;
 			}
 		}
-	} else { // Re attempt after a failed transfer
+	} else {
 		if (!memcmp(val, "wang", 5)) {
 			free(data);
 			c = 0;
 			data = malloc(sizeof(data_legacy_t));
 			if (!data) {
-				PRINT("insufficient memory\n");
+				char buf[32];
+				int blen = snprintf(buf, sizeof(buf), "BLE: malloc failed\n");
+				cdc_tx_poll((uint8_t *)buf, blen, 10);
 				return -3;
 			}
 		}
 	}
 
-	PRINT("Copying BLE value\n");
 	memcpy(data + c * len, val, len);
 
 	if (c == 1) {
 		data_legacy_t *d = (data_legacy_t *)data;
 		n = bigendian16_sum(d->sizes, 8);
 		data_len = LEGACY_HEADER_SIZE + LED_ROWS * n;
-		PRINT("Data len: %d\n", data_len);
+		char buf[48];
+		int blen = snprintf(buf, sizeof(buf), "BLE: data_len=%d\n", data_len);
+		cdc_tx_poll((uint8_t *)buf, blen, 10);
 		data = realloc(data, data_len);
 		if (!data) {
-			PRINT("insufficient memory\n");
+			char buf2[32];
+			int blen2 = snprintf(buf2, sizeof(buf2), "BLE: realloc failed\n");
+			cdc_tx_poll((uint8_t *)buf2, blen2, 10);
 			return -3;
 		}
 	}
 
 	if (c > 2 && ((c+1) * LEGACY_TRANSFER_WIDTH) >= data_len) {
-		PRINT("All bitmaps data received successfully\nWriting to flash.. ");
+		char buf[32];
+		int blen = snprintf(buf, sizeof(buf), "BLE: transfer complete\n");
+		cdc_tx_poll((uint8_t *)buf, blen, 10);
 		data_legacy_t *d = (data_legacy_t *)data;
 		RTC_InitTime(2000 + ((d->timestamp[0] - 208 + 256) % 256), d->timestamp[1], d->timestamp[2], d->timestamp[3], d->timestamp[4], d->timestamp[5]);
 		data_flatSave(data, data_len);
 		free(data);
 		data = NULL;
 		handle_after_rx();
-		PRINT("Done\n");
 	}
 
 	c++;

--- a/src/legacyctrl.c
+++ b/src/legacyctrl.c
@@ -178,3 +178,8 @@ int legacy_usb_rx(uint8_t *buf, uint16_t len)
 	}
 	return 0;
 }
+
+void legacy_bypass_auth()
+{
+    authorized = 1;   // skip auth entirely if KEY4 is pressed
+}

--- a/src/legacyctrl.h
+++ b/src/legacyctrl.h
@@ -9,5 +9,6 @@ int legacy_usb_rx(uint8_t *buf, uint16_t len);
 
 void legacy_set_auth_code(uint16_t code);  // called from main.c on BT-PAIRING entry
 void legacy_reset_auth();                   // called from peripheral.c on disconnect
+void legacy_bypass_auth();
 
 #endif /* __LEGACYCTRL_H__ */

--- a/src/legacyctrl.h
+++ b/src/legacyctrl.h
@@ -7,4 +7,7 @@ void handle_after_rx();
 int legacy_ble_rx(uint8_t *val, uint16_t len);
 int legacy_usb_rx(uint8_t *buf, uint16_t len);
 
+void legacy_set_auth_code(uint16_t code);  // called from main.c on BT-PAIRING entry
+void legacy_reset_auth();                   // called from peripheral.c on disconnect
+
 #endif /* __LEGACYCTRL_H__ */

--- a/src/main.c
+++ b/src/main.c
@@ -486,6 +486,7 @@ static void menu_select(){
 			} else {
 				ble_enable_advertise();
 				start_ble_animation();
+				auxbtn_onOnePress(KEY4, return_to_menu);
 			}
 			break;
         case 2:
@@ -624,6 +625,7 @@ static void security_submenu_select()
 static void bt_pairing_bypass()
 {
     legacy_bypass_auth();       // skip auth for this session
+	auxbtn_onOnePress(KEY4, return_to_menu);  // restore KEY4 to normal
     start_ble_animation();      // drop PIN display, show BT animation
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -481,6 +481,7 @@ static void menu_select(){
 				uint16_t auth_code = tmos_rand() % 10000;
 				legacy_set_auth_code(auth_code);
 				ble_enable_advertise();
+				auxbtn_onOnePress(KEY4, bt_pairing_bypass);
 				disp_auth_code(auth_code);
 			} else {
 				ble_enable_advertise();
@@ -618,6 +619,12 @@ static void security_submenu_select()
     badge_cfg.ble_security = (security_submenu_sel == 0) ? 1 : 0;
     cfg_writeflash_def(&badge_cfg);
     return_to_menu();
+}
+
+static void bt_pairing_bypass()
+{
+    legacy_bypass_auth();       // skip auth for this session
+    start_ble_animation();      // drop PIN display, show BT animation
 }
 
 static void enter_security_submenu()

--- a/src/main.c
+++ b/src/main.c
@@ -85,7 +85,6 @@ static void change_brightness()
 	NEXT_STATE(badge_cfg.led_brightness, 0, BRIGHTNESS_LEVELS);
 }
 
-static void mode_setup_download();
 static void mode_setup_normal();
 static void disp_clock();
 static void disp_menu();
@@ -95,6 +94,7 @@ static void enter_clock_submenu();
 static void disp_stopwatch();
 void return_to_menu();
 static void enter_security_submenu();
+static void bt_pairing_
 
 __HIGH_CODE
 /*static void change_mode()
@@ -690,22 +690,6 @@ static void disp_charging()
 			return;
 		}
 	}
-}
-
-static void mode_setup_download()
-{
-	// If always-on BLE is enabled, then skip this mode, jump to next mode
-	/*if (badge_cfg.ble_always_on) {
-		change_mode();
-	}*/
-
-	// Disable bitmap transition while in download mode
-	btn_onOnePress(KEY2, NULL);
-
-	// Take control of the current bitmap to display
-	// the Bluetooth animation
-	ble_enable_advertise();
-	start_ble_animation();
 }
 
 void clean_bmlist()

--- a/src/main.c
+++ b/src/main.c
@@ -94,7 +94,7 @@ static void enter_clock_submenu();
 static void disp_stopwatch();
 void return_to_menu();
 static void enter_security_submenu();
-static void bt_pairing_
+static void bt_pairing_bypass();
 
 __HIGH_CODE
 /*static void change_mode()

--- a/src/main.c
+++ b/src/main.c
@@ -39,12 +39,13 @@ enum MODES {
 };
 
 static int menu_cursor=0;
-#define MENU_ITEMS_COUNT 5
+#define MENU_ITEMS_COUNT 6
 static const char *menu_labels[] = {
 	"ANIMATION",
 	"BT-PAIRING",
 	"CLOCK MODE",
 	"SNAKE",
+	"SECURITY",
 	"OFF"
 };
 
@@ -93,6 +94,7 @@ static void menu_down();
 static void enter_clock_submenu();
 static void disp_stopwatch();
 void return_to_menu();
+static void enter_security_submenu();
 
 __HIGH_CODE
 /*static void change_mode()
@@ -475,12 +477,15 @@ static void menu_select(){
             break;
         case 1:
 			mode = DOWNLOAD;
-			btn_onOnePress(KEY1, NULL);
-			btn_onOnePress(KEY2, NULL);
-			uint16_t auth_code = tmos_rand() % 10000;  // 0000–9999
-			legacy_set_auth_code(auth_code);
-			ble_enable_advertise();
-			disp_auth_code(auth_code);                 // show code instead of BLE animation
+			if (badge_cfg.ble_security) {
+				uint16_t auth_code = tmos_rand() % 10000;
+				legacy_set_auth_code(auth_code);
+				ble_enable_advertise();
+				disp_auth_code(auth_code);
+			} else {
+				ble_enable_advertise();
+				start_ble_animation();
+			}
 			break;
         case 2:
             enter_clock_submenu();
@@ -491,6 +496,9 @@ static void menu_select(){
 			game_start((uint16_t *)fb);
             break;
 		case 4:
+			enter_security_submenu();
+			break;
+		case 5:
 			mode = POWER_OFF;
 			poweroff();
 			break;
@@ -583,6 +591,35 @@ static void clock_submenu_select()
         auxbtn_onOnePress(KEY3, NULL);
         auxbtn_onOnePress(KEY4, sw_back);
     }
+}
+
+static void disp_security_submenu()
+{
+    memset(fb, 0, sizeof(fb));
+    if (badge_cfg.ble_security)
+        fb_putchar_small('>', 0, 0);
+    else
+        fb_putchar_small('>', 0, 6);
+
+    fb_puts_small("ENABLE", 6, 4, 0);
+    fb_puts_small("DISABLE", 7, 4, 6);
+}
+
+static void security_submenu_nav()
+{
+    badge_cfg.ble_security ^= 1;
+    cfg_writeflash_def(&badge_cfg);
+	return_to_menu();
+}
+
+static void enter_security_submenu()
+{
+    stop_all_animation();
+    btn_onOnePress(KEY1, security_submenu_nav);
+    btn_onOnePress(KEY2, security_submenu_nav);
+    auxbtn_onOnePress(KEY3, NULL);
+    auxbtn_onOnePress(KEY4, return_to_menu);
+    disp_security_submenu();
 }
 
 static void enter_clock_submenu()

--- a/src/main.c
+++ b/src/main.c
@@ -593,10 +593,12 @@ static void clock_submenu_select()
     }
 }
 
+static int security_submenu_sel = 0;  // 0 = ENABLE, 1 = DISABLE 
+
 static void disp_security_submenu()
 {
     memset(fb, 0, sizeof(fb));
-    if (badge_cfg.ble_security)
+    if (security_submenu_sel == 0)
         fb_putchar_small('>', 0, 0);
     else
         fb_putchar_small('>', 0, 6);
@@ -607,18 +609,26 @@ static void disp_security_submenu()
 
 static void security_submenu_nav()
 {
-    badge_cfg.ble_security ^= 1;
+    security_submenu_sel ^= 1;
+    disp_security_submenu();
+}
+
+static void security_submenu_select()
+{
+    badge_cfg.ble_security = (security_submenu_sel == 0) ? 1 : 0;
     cfg_writeflash_def(&badge_cfg);
-	return_to_menu();
+    return_to_menu();
 }
 
 static void enter_security_submenu()
 {
     stop_all_animation();
-    btn_onOnePress(KEY1, security_submenu_nav);
-    btn_onOnePress(KEY2, security_submenu_nav);
-    auxbtn_onOnePress(KEY3, NULL);
-    auxbtn_onOnePress(KEY4, return_to_menu);
+    // cursor starts on current state
+    security_submenu_sel = badge_cfg.ble_security ? 0 : 1;
+    btn_onOnePress(KEY1, security_submenu_nav);   // navigate up/down
+    btn_onOnePress(KEY2, security_submenu_nav);   // navigate up/down
+    auxbtn_onOnePress(KEY3, security_submenu_select);  // confirm
+    auxbtn_onOnePress(KEY4, return_to_menu);           // cancel
     disp_security_submenu();
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -401,6 +401,18 @@ static void fb_puts_small(char *s, int len, int col, int row)
     }
 }
 
+static void disp_auth_code(uint16_t code)
+{
+	memset(fb, 0, sizeof(fb));
+	char buf[5];
+	buf[0] = '0' + (code / 1000) % 10;
+	buf[1] = '0' + (code / 100)  % 10;
+	buf[2] = '0' + (code / 10)   % 10;
+	buf[3] = '0' + (code)        % 10;
+	buf[4] = '\0';
+	fb_puts(buf, 4, 8, 2);   // centered on 44-col display, row 2
+}
+
 static void disp_clock()
 {
     uint16_t year, month, day, hour, minute, second;
@@ -462,12 +474,14 @@ static void menu_select(){
             mode_setup_normal();
             break;
         case 1:
-            mode = DOWNLOAD;
-            btn_onOnePress(KEY1, NULL);
-            btn_onOnePress(KEY2, NULL);
-            ble_enable_advertise();
-            start_ble_animation();
-            break;
+			mode = DOWNLOAD;
+			btn_onOnePress(KEY1, NULL);
+			btn_onOnePress(KEY2, NULL);
+			uint16_t auth_code = tmos_rand() % 10000;  // 0000–9999
+			legacy_set_auth_code(auth_code);
+			ble_enable_advertise();
+			disp_auth_code(auth_code);                 // show code instead of BLE animation
+			break;
         case 2:
             enter_clock_submenu();
             break;


### PR DESCRIPTION
Closes #72 
The badge's BT-PAIRING mode accepted bitmap transfers from any nearby device i.e anyone running the app within BLE range could overwrite the display without the owner's knowledge or consent. Added an application-layer authentication gate on top of the existing BLE connection flow. When the badge enters BT-PAIRING mode, it generates a random 4-digit code and displays it on the LED matrix. Any device attempting to transfer data must first send the correct code before the badge will accept a 'wang' transfer and without it, all writes are rejected.

Reviewer's Guide:
https://github.com/fossasia/badgemagic-app/pull/1783#issuecomment-4783933045
This feature is dependent on the app and requires the above PR to be merged in the badgmagic-app repo