### PR TITLE
feat: report hardware revision via BLE Device Information Service

### DIFF
--- a/src/ble/profile/devinfo.c
+++ b/src/ble/profile/devinfo.c
@@ -23,7 +23,7 @@ const uint16_t          firmwareRev_UUID = FIRMWARE_REV_UUID;
 static const uint8_t    firmwareRev_val[] = USBC_VER_PREFIX VERSION;
 
 const uint16_t          hardwareRev_UUID = HARDWARE_REV_UUID;
-static const uint8_t    hardwareRev_val[] = "20240908";
+static const uint8_t    hardwareRev_val[] = "REV3";
 
 const uint16_t          softwareRev_UUID = SOFTWARE_REV_UUID;
 static const uint8_t    softwareRev_val[] = "N/A";


### PR DESCRIPTION
Fixes #166 
Its a minor tweak but will enable the app to be able to detect which hardware version is being run on the badge upon reading the UUID 0x2A27 characteristic. This is based of PR #122 where the following changes are being implemented.
Rev 1 would be USB-B-Micro, Rev 2 USB-C (two buttons) and Rev 3 USB-C (four buttons).
So the idea is that, the developer for any of the hardware versions will modify this particular characteristic before releasing the firmware. I am currently doing it for the Rev 3 i.e 4 button hardware version.