### PR TITLE
fix: Remove excess initializers from led_pins[]

### DIFF
--- a/src/leddrv.c
+++ b/src/leddrv.c
@@ -101,12 +101,10 @@ static const pindesc_t led_pins[LED_PINCOUNT] = {
 	PINDESC(A, 11), // G
 	PINDESC(B, 9),  // H
 	PINDESC(B, 8),  // I
-  PINDESC(B, 8),  // I
 #ifdef HARDWARE_REV3
 	PINDESC(B, 17), // J
 #else
 	PINDESC(B, 15), // J
-	PINDESC(B, 14), // K
 #endif
 #ifdef HARDWARE_REV3
 	PINDESC(B, 16), // K


### PR DESCRIPTION
Fixes #177

## Problem

`led_pins[]` is declared with `LED_PINCOUNT` (23) entries, but the initializer expands to **25** in the default configuration and **24** with `HARDWARE_REV3`. C discards the excess, so this is only a warning — and the entries that fall off the end are silently lost.

The compiler says exactly which ones:

```
src/leddrv.c:89:32: warning: excess elements in array initializer
src/leddrv.c:130:9: note: in expansion of macro 'PINDESC'    <- PINDESC(B, 20), // V
src/leddrv.c:89:32: warning: excess elements in array initializer
src/leddrv.c:131:9: note: in expansion of macro 'PINDESC'    <- PINDESC(B, 19), // W
```

So `W`/PB19 is dropped in **every** configuration, and `V`/PB20 as well in the default build. Those pins never get OR'd into `bankpins_mask` by `led_init()`, so `led_write2dcol_raw()` never drives them and their LED columns stay dark. Every position after the first stray entry is also shifted, so the remaining columns are driven by the wrong pins.

## Cause

Two strays, both introduced in eb6e9da ("Display fix", #122) when the `HARDWARE_REV*` conditionals were added:

- `I`/PB8 is duplicated — note the stray line uses spaces where the rest of the table uses tabs
- the old `K`/PB14 was left behind inside the new `J` block

## Why this matches #177

The report there is that #169 displays badly while #155 is fine, which brackets the regression:

- #155 (snake, 7ba8abc) predates eb6e9da
- #169 (flappy, 7ce05e7) follows it

Dropped columns plus every later position shifted onto the wrong pin is consistent with output that is legible in outline but "not very clear", and it explains why the fault is independent of which game commit is on top — everything built after eb6e9da carries it.

## Fix

Delete both strays. That leaves exactly 23 entries with no duplicates in every configuration:

| Config | Before | After |
|---|---|---|
| default | 25 | 23 |
| `HARDWARE_REV3=1` | 24 | 23 |

Verified by running the table through the preprocessor and counting `PINDESC` expansions, and separately checking that no pin appears twice.

## Testing

- Builds clean in both configurations with the MounRiver toolchain the CI uses (`MRS_Toolchain_Linux_x64_V1.92`), and the `excess elements` warning is gone.
- Flashed and confirmed on hardware: the columns driven by the dropped pins light up.

This is independent of any board revision — it's a plain array overflow, so it applies to all of them.
