### PR TITLE
fix: Stop rendering trailing padding as a blank frame

### DIFF
--- a/src/animation.c
+++ b/src/animation.c
@@ -170,11 +170,39 @@ int ani_scroll_right(bm_t *bm, uint16_t *fb)
 	return ani_scroll_x(bm, fb, 1);
 }
 
+/* Width ignoring trailing all-blank columns.
+ *
+ * The legacy upload format sizes bitmaps in 8-pixel chunks while the display
+ * is LED_COLS (44) wide, which is not a multiple of 8. A message is therefore
+ * always a multiple of 8 columns and routinely carries a few blank ones past
+ * the end of its content: a name occupying 41 columns is stored as 48.
+ *
+ * Counting that padding as content makes ALIGN() report a second frame, which
+ * still mode then renders as a full frame of darkness -- 8.8 seconds at the
+ * slowest speed, alternating with the message. */
+static int visible_width(bm_t *bm)
+{
+	int w = bm->width;
+
+	while (w > 0 && bm->buf[w - 1] == 0)
+		w--;
+
+	return w;
+}
+
+/* Frame count for the paged (non-scrolling) modes, padding excluded. */
+static int still_frames(bm_t *bm)
+{
+	int w = visible_width(bm);
+
+	return (w > 0) ? ALIGN(w, LED_COLS) / LED_COLS : 1;
+}
+
 /* Returns horizontal centering offset for a frame.
  * Returns 0 if content fills the full width (no centering needed). */
 static int get_x_offset(bm_t *bm, int frame)
 {
-	int frames = ALIGN(bm->width, LED_COLS) / LED_COLS;
+	int frames = still_frames(bm);
 	if (frames > 1)
 		return 0;
 
@@ -414,7 +442,7 @@ int ani_animation(bm_t *bm, uint16_t *fb)
 int ani_fixed(bm_t *bm, uint16_t *fb)
 {
 	int frame_steps = ANI_FIXED_STEPS;
-	int frames = ALIGN(bm->width, LED_COLS) / LED_COLS;
+	int frames = still_frames(bm);
 	int total_steps = frame_steps * frames;
 	int frame = mod(bm->anim_step, total_steps)/frame_steps;
 


### PR DESCRIPTION
Fixes #179

## Problem

A badge showing a single short message in still mode, with no effects enabled, alternates between the message and a fully blank screen — roughly 8.5 s each, forever. It looks like a second message is loaded when only one is.

## Cause

The legacy upload format sizes bitmaps in **8-pixel chunks**, but `LED_COLS` is **44**, which is not a multiple of 8. A message is therefore always a multiple of 8 columns wide and routinely carries blank padding past the end of its content: a name occupying 41 columns is stored as 48.

`ani_fixed()` counts that padding as content when deciding how many frames the bitmap needs:

```c
int frames = ALIGN(bm->width, LED_COLS) / LED_COLS;   // ALIGN(48,44)/44 = 2
int total_steps = frame_steps * frames;               // 88 steps
```

So a 48-column bitmap becomes two pages: frame 0 holds the message, frame 1 holds columns 44–87, which are padding. `still()` zero-fills everything past `bm->width`, so frame 1 is a blank screen shown for a full frame period.

The arithmetic matches the observed timing exactly — `ANI_FIXED_STEPS` is `LED_COLS` (44), and `ANI_SPEED_STRATEGY(0)` is 200000 µs:

```
44 steps x 200 ms = 8.8 s per frame
```

Any message whose content does not end exactly on a 44-column boundary is affected, which is most of them.

## Fix

Compute the frame count from the visible width, ignoring trailing all-blank columns:

```c
static int visible_width(bm_t *bm);   /* trailing zero columns are padding */
static int still_frames(bm_t *bm);    /* ALIGN() over the visible width */
```

`ani_fixed()` and `get_x_offset()` both use `still_frames()` so they cannot disagree about how many pages a bitmap has.

Scrolling modes are deliberately untouched: `ani_scroll_x()` pages on `bm->width` directly and never consults the frame count, so its behaviour is unchanged.

## Side effect: centring starts working

`get_x_offset()` returns 0 whenever `frames > 1`, so the spurious second frame was also suppressing the centring added in #164. With the frame count corrected, affected messages are centred as that change intended rather than left-aligned.

## Testing

- Builds clean with the MounRiver toolchain the CI uses (`MRS_Toolchain_Linux_x64_V1.92`), in both `KEY_COUNT=4` and `KEY_COUNT=2`.
- Flashed and confirmed on hardware: the message stays on screen continuously, and short messages are now centred.

Independent of board revision and of key count — it is purely a frame-count calculation.
