### PR TITLE
Revert "fix: Remove excess initializers from led_pins[]"

### DIFF
--- a/src/leddrv.c
+++ b/src/leddrv.c
@@ -101,10 +101,12 @@ static const pindesc_t led_pins[LED_PINCOUNT] = {
 	PINDESC(A, 11), // G
 	PINDESC(B, 9),  // H
 	PINDESC(B, 8),  // I
+  PINDESC(B, 8),  // I
 #ifdef HARDWARE_REV3
 	PINDESC(B, 17), // J
 #else
 	PINDESC(B, 15), // J
+	PINDESC(B, 14), // K
 #endif
 #ifdef HARDWARE_REV3
 	PINDESC(B, 16), // K


### PR DESCRIPTION
Reverts fossasia/badgemagic-firmware#178
I tested this PR on the badge and I am still seeing the same display issue on the 4 key badge
The contributor did mention he got it working on some badge 
@bkero Could you please share the details and a picture if possible of this PR working
![20260726_113544.jpg](https://github.com/user-attachments/assets/dcf20c91-9682-4dde-a381-e48ad7527339)





## Summary by Sourcery

Bug Fixes:
- Restore LED pin configuration for badges that were displaying incorrectly after the prior led_pins[] change.