### PR TITLE
Fix display issue

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,10 +37,10 @@ jobs:
       - name: Build firmware
         run: |
           export PREFIX=${{ env.MRS_TOOLCHAIN }}/RISC-V_Embedded_GCC/bin/riscv-none-embed-
-          BUILD_DIR=${{ env.USBC_4KEY_BUILD_DIR }} USBC_VERSION=1 KEY_COUNT=4 make -j$(nproc)
-          BUILD_DIR=${{ env.USBC_2KEY_BUILD_DIR }} USBC_VERSION=1 KEY_COUNT=2 make -j$(nproc)
-          BUILD_DIR=${{ env.MICROB_4KEY_BUILD_DIR }} KEY_COUNT=4 make -j$(nproc)
-          BUILD_DIR=${{ env.MICROB_2KEY_BUILD_DIR }} KEY_COUNT=2 make -j$(nproc)
+          BUILD_DIR=${{ env.USBC_4KEY_BUILD_DIR }} HARDWARE_REV3=1 KEY_COUNT=4 make -j$(nproc)
+          BUILD_DIR=${{ env.USBC_2KEY_BUILD_DIR }} KEY_COUNT=2 make -j$(nproc)
+          BUILD_DIR=${{ env.MICROB_4KEY_BUILD_DIR }} HARDWARE_REV1=1 KEY_COUNT=4 make -j$(nproc)
+          BUILD_DIR=${{ env.MICROB_2KEY_BUILD_DIR }} HARDWARE_REV1=1 KEY_COUNT=2 make -j$(nproc)
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Fixes #177 and gets the merged PR #178 working
The CI build matrix in build.yaml still passes USBC_VERSION=1 to make, but this flag was retired in aa890e9 ("build!: switch to hardware revision build flags") in favor of HARDWARE_REV1/HARDWARE_REV3. Since USBC_VERSION is no longer read anywhere in source, none of the four official CI artifacts ever define HARDWARE_REV3 — including usb-c-4key, the artifact a 4-button (Rev3) board owner would flash.

As a result, src/leddrv.c's #ifdef HARDWARE_REV3 branch (correct J/K/T pin mapping: PB17/PB16/PB6) is never compiled in, and every build silently falls back to the old pin mapping instead. 

Reviewer's Guide:
Test the micro-b-4key and micro-b-2key builds on an actual MicroUSB badge (the original, non-USB-C hardware revision) as I only have the usb-c-key4 badge version and its working on that now

![20260727_004049.jpg](https://github.com/user-attachments/assets/70550865-66bd-4eff-9ee8-b88b4e417314)

